### PR TITLE
set labels=True by default

### DIFF
--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -184,14 +184,14 @@ class LimeSurvey:
     def get_responses(
         self,
         question: str,
-        labels: bool = False,
+        labels: bool = True,
         drop_other: bool = False,
     ) -> pd.DataFrame:
         """Get responses for a given question with or without labels
 
         Args:
             question (str): Question to get the responses for.
-            labels (bool, optional): If the response consists of labels or not (default False).
+            labels (bool, optional): If the response consists of labels or not (default True).
             drop_other (bool, optional): Whether to exclude contingent question (i.e. "other")
 
         Raises:
@@ -235,7 +235,7 @@ class LimeSurvey:
     def count(
         self,
         question: str,
-        labels: bool = False,
+        labels: bool = True,
         dropna: bool = False,
         add_totals: bool = False,
         percents: bool = False,
@@ -244,7 +244,7 @@ class LimeSurvey:
 
         Args:
             question (str): Name of a question group or a sinlge column
-            labels (bool, optional): Use labels instead of codes. Defaults to False.
+            labels (bool, optional): Use labels instead of codes. Defaults to True.
             dropna (bool, optional): Do not count empty values. Defaults to False.
             add_totals (bool, optional): Add a column and a row with totals. Values
               set to NA if they do not make sense. For example, sums by row for


### PR DESCRIPTION
## Description

The following issue was addressed: #60 
Set labels=True as default in LimeSurvey Class.


## Checklist
- [x] In all methods of the LimeSurvey class having labels argument, set labels=True by default.
- [x] Update tests accordingly (all tests passed without additional tests needed)
## PR review

Anyone in the community is free to review the PR once the tests have passed.

- [ ] Add labels and milestones to the PR so it can be classified.
- [x] Check that all items from the **checklist** are resolved.
- [x] Is this pull request ready for review?