### PR TITLE
#10 simple plot comparison: added plot_compare function to lime /survey.py

### DIFF
--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -483,6 +483,21 @@ class LimeSurvey:
             print(f"Saved plot to {fullpath}")
 
         fig.show()
+    
+    def plot_compare(
+        self,
+        questions,
+        kind: str = None,
+        save: Union[str, bool] = False,
+        **kwargs,
+    ):
+        if type(questions) == str:
+            self.plot(question = questions,
+                      kind = kind,
+                      save = save,
+                      **kwargs)
+        elif type(questions) == list:
+            brakk
 
     def get_question(self, question: str, drop_other: bool = False) -> pd.DataFrame:
         """Get question structure (i.e. subset from self.questions)

--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -487,10 +487,31 @@ class LimeSurvey:
     def plot_compare(
         self,
         questions,
+        answer_subset = False,
         kind: str = None,
         save: Union[str, bool] = False,
+        totalbar = True,
+        no_answers = True,
+        hide_titles = False,
+        spacing_bar = False,
+        save = False,
         **kwargs,
     ):
+        '''
+        function to compare plots in the same figure, can be added to the "plot"
+        function above. The function decides from questions input type: 
+            if input is just str it will use the normal plot function, 
+            if input is list type it will plot the entries next to each other
+               depending on the dimension and length of the entries:
+                   questions = [[A1,B1],
+                                [A6,B6]] --> [[A1 top left, B1 top right],
+                                              [A6 bot left, B6 bot right]]
+        '''
+        if any([totalbar,hide_titles,spacing_bar, no_answers, answer_subset]):
+               raise NotImplementedError(
+                   'Not yet implemented'
+               )
+               
         if type(questions) == str:
             self.plot(question = questions,
                       kind = kind,

--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -494,31 +494,63 @@ class LimeSurvey:
         no_answers = True,
         hide_titles = False,
         spacing_bar = False,
-        save = False,
         **kwargs,
     ):
         '''
-        function to compare plots in the same figure, can be added to the "plot"
-        function above. The function decides from questions input type: 
+        function to compare plots in the same figure, can be added to the 
+        "plot" function above. The function decides from questions input type: 
             if input is just str it will use the normal plot function, 
             if input is list type it will plot the entries next to each other
                depending on the dimension and length of the entries:
-                   questions = [[A1,B1],
-                                [A6,B6]] --> [[A1 top left, B1 top right],
-                                              [A6 bot left, B6 bot right]]
+                   questions = [[A,B],
+                                [C,D]] --> [[A top left, B top right],
+                                              [C bot left, D bot right]]
+        the function for now only works for single choice questions
         '''
-        if any([totalbar,hide_titles,spacing_bar, no_answers, answer_subset]):
-               raise NotImplementedError(
-                   'Not yet implemented'
-               )
-               
+        
+        if kind is not None:
+            raise NotImplementedError(
+                "Forced plot type is not supported yet."
+            )
+        
+        # switch to plot function if only one question is given --> userfriendly
+        # we can also make this an "use different function" error
         if type(questions) == str:
             self.plot(question = questions,
                       kind = kind,
                       save = save,
                       **kwargs)
         elif type(questions) == list:
-            brakk
+            # stop when options are not yet implemented
+            if any([totalbar,hide_titles,spacing_bar, no_answers,
+                    answer_subset]):
+               raise NotImplementedError(
+                   'Not yet implemented'
+               )
+            # Set up plot options
+            theme = self.theme.copy()
+            theme.update(kwargs)
+               
+            if type(questions[0]) == str:
+                print('''
+                      Assuming plot horizontaly next to each other,
+                      for more control on placement use:
+                          questions = [[A,B,C],
+                                       [D,E,F]]
+                      ''')
+                questions = [questions]
+            for row in questions:
+                # test if question type is supported
+                for question in row:
+                    if self.get_question_type(question) != 'single-choice':
+                       raise NotImplementedError(
+                           '''only single-choice questions implemented at the
+                           moment.
+                           '''
+                       )
+               
+                        
+                
 
     def get_question(self, question: str, drop_other: bool = False) -> pd.DataFrame:
         """Get question structure (i.e. subset from self.questions)

--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -505,7 +505,6 @@ class LimeSurvey:
                    questions = [[A,B],
                                 [C,D]] --> [[A top left, B top right],
                                               [C bot left, D bot right]]
-        the function for now only works for single choice questions
         '''
         
         if kind is not None:
@@ -548,6 +547,9 @@ class LimeSurvey:
                            moment.
                            '''
                        )
+                    else:
+                        print('currently under construction')
+           
                
                         
                 

--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -490,8 +490,8 @@ class LimeSurvey:
         answer_subset = False,
         kind: str = None,
         save: Union[str, bool] = False,
-        totalbar = True,
-        no_answers = True,
+        totalbar = False,
+        no_answers = False,
         hide_titles = False,
         spacing_bar = False,
         **kwargs,
@@ -510,7 +510,7 @@ class LimeSurvey:
         
         if kind is not None:
             raise NotImplementedError(
-                "Forced plot type is not supported yet."
+                'Forced plot type is not supported yet.'
             )
         
         # switch to plot function if only one question is given --> userfriendly
@@ -525,7 +525,7 @@ class LimeSurvey:
             if any([totalbar,hide_titles,spacing_bar, no_answers,
                     answer_subset]):
                raise NotImplementedError(
-                   'Not yet implemented'
+                   f'option not yet implemented'
                )
             # Set up plot options
             theme = self.theme.copy()
@@ -539,8 +539,8 @@ class LimeSurvey:
                                        [D,E,F]]
                       ''')
                 questions = [questions]
+            # test if question type is supported
             for row in questions:
-                # test if question type is supported
                 for question in row:
                     if self.get_question_type(question) != 'single-choice':
                        raise NotImplementedError(


### PR DESCRIPTION
Hi I am Felix Schindler and I think I was not yet added to the github repository.

I was assigned the #10 simple_comparison plots issues on the last meeting before the holidays.
Since I couldn't push to the repository itself, I forked it (never worked before with github, only gitlab, so I was just courious to try it).

I of course started adding the call for the plot_comparison function in the main branch, since I forgot to create my own branch, then I did create the 10_simple_comparison_plots branch and finished the call function in survey.py.

Since it does not yet do anything except rerouting to the existing plot function, I remerged the 10 branch back to main instead of rewinding the main branch.

Everything should work fine if this fork is merged back. 
I kept the style as close as possible to the already existing plot function in survey.py.

Since I now understand the structure (never knew of " __all__ " before, but it explains now why my own library has thousands of lines while everyone else seems to only have a couple of hundreds at most :D) I will start to write the actual plotting function in a separate file and keep as close as possible to the plot/bar.py script... I'll start on my branch this time.

Can you add me to the repository, so I can formally claim the issue #10 and push directly to it?

Thanks and happy holidays



