### PR TITLE
94 change default filename for comp plots

### DIFF
--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -572,6 +572,7 @@ class LimeSurvey:
         dpi: Union[str, float] = "figure",
         answer_sequence: list = [],
         legend_title: Union[str, bool] = None,
+        legend_sequence: list = [],
         kind: str = None,
         **kwargs,
     ):
@@ -643,11 +644,16 @@ class LimeSurvey:
             legend_title = self.get_label(compare_with)
         if compare_with:
             # load necessary data for comparison
+            if not legend_sequence:
+                legend_sequence = list(self.count(
+                    compare_with,labels=True
+                    ).index.values.astype(str))
             if not answer_sequence:
                 answer_sequence = self.get_answer_sequence(
                     question, add_questions=add_questions, totalbar=totalbar
                 )
-            plot_data_list, answer_sequence = self.create_comparison_data(
+            (plot_data_list,
+             answer_sequence) = self.create_comparison_data(
                 question, compare_with, answer_sequence, add_questions=add_questions
             )
         if question_type == "single-choice":
@@ -675,6 +681,7 @@ class LimeSurvey:
                     plot_title_position=plot_title_position,
                     legend_title=legend_title,
                     answer_sequence=answer_sequence,
+                    legend_sequence=legend_sequence
                 )
 
             else:

--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -568,6 +568,8 @@ class LimeSurvey:
         plot_title: Union[str, bool] = True,
         plot_title_position: tuple = (()),
         save: Union[str, bool] = False,
+        file_format: str = "png",
+        dpi: Union[str, float] = "figure",
         answer_sequence: list = [],
         legend_title: Union[str, bool] = None,
         kind: str = None,
@@ -608,6 +610,10 @@ class LimeSurvey:
                 and 'legend_columns'
             'save': save plot as png either with question indicator as name
                 if True or as string if string is added here
+                'file_format': if you want to save the file as .pdf rather
+                    then as png
+                'dpi': well... resolution in dotsperinch if you want to specify
+                    else, the resolution is taken from the figure
             'answer_sequence': getting the answers in the right order made the
             inclusion of an answer_sequence variable necessary, which also
             can be used if you want to give the order of bars yourself,
@@ -720,15 +726,15 @@ class LimeSurvey:
 
         # Save to a file
         if save:
-            # default file name is the question-ID, default format is *.png
-            filename = f"{question}.png"
-            if isinstance(save, str):
-                filename = save
-            # Make a valid file name
-            filename = _clean_file_name(filename)
-            fullpath = os.path.join(self.output_folder, filename)
-            fig.savefig(fullpath)
-            print(f"Saved plot to {fullpath}")
+            self.save_plot(
+                fig,
+                question,
+                compare_with=compare_with,
+                add_questions=add_questions,
+                save=save,
+                file_format=file_format,
+                dpi=dpi,
+            )
         return fig, ax
 
     def save_plot(

--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -731,6 +731,39 @@ class LimeSurvey:
             print(f"Saved plot to {fullpath}")
         return fig, ax
 
+    def save_plot(
+        self,
+        fig,
+        question,
+        compare_with: str = None,
+        add_questions: list = [],
+        save: Union[str, bool] = False,
+        file_format: str = "png",
+        dpi: Union[str, float] = "figure",
+    ):
+        """
+        creates 'filename' from 'question' and, if given, 'compare_with' and
+        'add_questions' and saves file to output_folder if 'save' is True.
+        'save' = string: string replaces savename of plot
+        'file_format': can be changed from pixelbased .png to .pdf
+        (vector graphics --> loss free scalable)
+        'dpi': specifies resolution in dots per inch for .png
+        """
+        if isinstance(save, str):
+            filename = save
+        else:
+            filename = f"{question}"
+            for entry in add_questions:
+                filename = filename + f"_{entry}"
+            if compare_with:
+                filename = filename + f"_vs_{compare_with}"
+            filename = filename + f".{file_format}"
+        filename = _clean_file_name(filename)
+        fullpath = os.path.join(self.output_folder, filename)
+        fig.savefig(fullpath, dpi=dpi)
+        print(f"Saved plot to {fullpath}")
+        return True
+
     def check_plot_implemented(self, question, compare_with=None, add_questions=[]):
         """
         Check if question type and/or combination of questions for

--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -645,15 +645,14 @@ class LimeSurvey:
         if compare_with:
             # load necessary data for comparison
             if not legend_sequence:
-                legend_sequence = list(self.count(
-                    compare_with,labels=True
-                    ).index.values.astype(str))
+                legend_sequence = list(
+                    self.count(compare_with, labels=True).index.values.astype(str)
+                )
             if not answer_sequence:
                 answer_sequence = self.get_answer_sequence(
                     question, add_questions=add_questions, totalbar=totalbar
                 )
-            (plot_data_list,
-             answer_sequence) = self.create_comparison_data(
+            (plot_data_list, answer_sequence) = self.create_comparison_data(
                 question, compare_with, answer_sequence, add_questions=add_questions
             )
         if question_type == "single-choice":
@@ -681,7 +680,7 @@ class LimeSurvey:
                     plot_title_position=plot_title_position,
                     legend_title=legend_title,
                     answer_sequence=answer_sequence,
-                    legend_sequence=legend_sequence
+                    legend_sequence=legend_sequence,
                 )
 
             else:

--- a/n2survey/plot/simple_comparison.py
+++ b/n2survey/plot/simple_comparison.py
@@ -219,6 +219,18 @@ def simple_comparison_plot(
     )
     # sort x and y to follow answer_sequence
     (x, y) = sort_data(answer_sequence, x, y)
+    # sort y to follow legend_sequence
+    count = 0
+    print(y)
+    for entry in y.copy():
+        legend_name, sorted_data = sort_data(legend_sequence, entry[:, 0], entry[:, 1])
+        y[count] = np.append(
+            np.reshape(legend_name, newshape=(-1, 1)),
+            np.reshape(sorted_data, newshape=(-1, 1)),
+            axis=1,
+        )
+        count = count + 1
+    print(y)
     # %% Prepare/Define figure
     fig, ax = plt.subplots()
     # %% split up y to list of answers of question 2 and list of percentages
@@ -227,7 +239,13 @@ def simple_comparison_plot(
     for entry in y:
         q2_answers.append(entry[:, 0])
         percentages.append(entry[:, 1].astype(np.float64))
-    all_answers = np.unique(np.concatenate(np.array(q2_answers, dtype=object)))
+    all_answers = legend_sequence.copy()
+    existing_answers = np.unique(np.concatenate(np.array(q2_answers, dtype=object)))
+    count = 0
+    for entry in all_answers.copy():
+        if entry not in existing_answers:
+            all_answers.pop(count)
+        count = count + 1
     percentage_all = []
     for (percentage, q2_answer) in zip(percentages, q2_answers):
         count = 0

--- a/n2survey/plot/simple_comparison.py
+++ b/n2survey/plot/simple_comparison.py
@@ -194,6 +194,7 @@ def simple_comparison_plot(
     plot_title_position: tuple = (()),
     legend_title: str = None,
     answer_sequence: list = [],
+    legend_sequence: list = [],
 ):
     """
     Plot correlations from the np.ndarray arrays in plot_data_list with the

--- a/n2survey/plot/simple_comparison.py
+++ b/n2survey/plot/simple_comparison.py
@@ -97,16 +97,26 @@ def form_bar_positions(df, bar_positions=False, totalbar=None, suppress_answers=
     bar_positions_complete = bar_positions or [0]
     count = 0
     number_of_answers = 0
+    total_bar_position_add = 0
+    if all([totalbar, bar_positions_complete == [0]]):
+        # necessary because I switch off total_bar later on to suppress the plot
+        # of multiple total_bars.... could probably be cleaner solved -->
+        # beautyfying code issue
+        total_bar_position_add = 0.5
     for answer_combinations in df:
+        # calculate percentages
         percentage_correlated_answers = get_percentages(
             answer_combinations, totalbar=totalbar
         )
         for answer in suppress_answers:
+            # remove suppressed answers
             if answer not in percentage_correlated_answers:
                 print(f"{answer} does not exist for this question")
             else:
                 percentage_correlated_answers.pop(answer)
         number_of_answers = number_of_answers + len(percentage_correlated_answers)
+        # set totalbar to None to not recalculate multiple total bars, since
+        # they are all the same 'compare_with' question answers
         totalbar = None
         if count > 0 and len(bar_positions_complete) == number_of_answers - len(
             percentage_correlated_answers
@@ -114,6 +124,11 @@ def form_bar_positions(df, bar_positions=False, totalbar=None, suppress_answers=
             bar_positions_complete.append(max(bar_positions_complete) + 1.5)
         while len(bar_positions_complete) < number_of_answers:
             bar_positions_complete.append(max(bar_positions_complete) + 1)
+        count = count + 1
+    # add space between total_bar and other bars
+    count = 1
+    for position in bar_positions_complete[1:].copy():
+        bar_positions_complete[count] = position + total_bar_position_add
         count = count + 1
     return bar_positions_complete
 

--- a/n2survey/plot/simple_comparison.py
+++ b/n2survey/plot/simple_comparison.py
@@ -221,7 +221,6 @@ def simple_comparison_plot(
     (x, y) = sort_data(answer_sequence, x, y)
     # sort y to follow legend_sequence
     count = 0
-    print(y)
     for entry in y.copy():
         legend_name, sorted_data = sort_data(legend_sequence, entry[:, 0], entry[:, 1])
         y[count] = np.append(
@@ -230,7 +229,6 @@ def simple_comparison_plot(
             axis=1,
         )
         count = count + 1
-    print(y)
     # %% Prepare/Define figure
     fig, ax = plt.subplots()
     # %% split up y to list of answers of question 2 and list of percentages


### PR DESCRIPTION
## Description

Bug fixes issue 94

Describe your solution:

Added new class `save_plot` to survey.py script which creates `filename` and save path and saves the figure depending on all used questions for creation of the figure.
added variable `legend_sequence`, the legend is now as well displayed in order of the answers of the compare_with question.
changed simple_comparison.py to add automatically extra space after totalbar

everything should work now.

## Checklist

- [x] I created an issue and discussed solutions with others.
- [x] I wrote tests or updated tests regarding my changes.
- [x ] I follow the style guidelines of this project.
- [ x] I have commented my code. So, other can understand what I did.
- [x] I checked if all tests passing after my changes.

## PR review

Anyone in the community is free to review the PR once the tests have passed.

- [ x ] Add labels and milestones to the PR so it can be classified.
- [x] Check that all items from the **checklist** are resolved.
- [x] Is this pull request ready for review?