### PR TITLE
Allow list of questions of the same transformation types

### DIFF
--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -238,6 +238,7 @@ class LimeSurvey:
             responses_file (str): Path to the responses CSV file
             transformation_questions (dict, optional): Dict of questions
                 requiring transformation of raw data, e.g. {'depression': 'D3'}
+                or {'supervision': ['E7a', 'E7b']}
 
         """
 
@@ -342,8 +343,11 @@ class LimeSurvey:
         self.responses = question_responses
         self.lime_system_info = system_info
 
-        for transform, question in transformation_questions.items():
-            self.add_responses(self.transform_question(question, transform))
+        for transform, questions in transformation_questions.items():
+            if not isinstance(questions, list):
+                questions = [questions]
+            for question in questions:
+                self.add_responses(self.transform_question(question, transform))
 
     def transform_question(self, question: str, transform: str):
         """Perform transformation on responses to given question
@@ -360,8 +364,7 @@ class LimeSurvey:
             "state_anxiety": "mental_health",
             "trait_anxiety": "mental_health",
             "depression": "mental_health",
-            "formal_supervision": "supervision",
-            "direct_supervision": "supervision",
+            "supervision": "supervision",
         }
 
         if transform_dict.get(transform) == "mental_health":

--- a/tests/test_lime_survey.py
+++ b/tests/test_lime_survey.py
@@ -212,10 +212,7 @@ class TestLimeSurveyReadResponses(BaseTestLimeSurvey2021WithResponsesCase):
     def test_supervision_transformation_questions(self):
         """Test adding responses to transformation questions in read_responses"""
 
-        supervision_questions = {
-            "formal_supervision": "E7a",
-            "direct_supervision": "E7b",
-        }
+        supervision_questions = {"supervision": ["E7a", "E7b"]}
 
         survey = LimeSurvey(structure_file=self.structure_file)
         survey.read_responses(
@@ -420,10 +417,10 @@ class TestLimeSurveyTransformQuestion(BaseTestLimeSurvey2021WithResponsesCase):
         """Test transforming two types of supervision questions"""
 
         formal_supervision_transformed = self.survey.transform_question(
-            "E7a", "formal_supervision"
+            "E7a", "supervision"
         )
         direct_supervision_transformed = self.survey.transform_question(
-            "E7b", "direct_supervision"
+            "E7b", "supervision"
         )
 
         formal_supervision_ref = pd.DataFrame(


### PR DESCRIPTION
## Description

Solution to Issue #115 , which was encoutered in PR #110 . 

Describe your solution:

- This eliminates the need for *essentially* duplicate entries to dict for `transformation_questions` argument of `read_responses` method
- Instead of having to write: 
```python
transformation_questions={
    "formal_supervision": "E7a",
    "direct_supervision": "E7b",
}
```
when both go through the exactly identical processing function but have to be distinguished because it was not possible to do:
```python
transformation_questions={
    "supervision": ["E7a", "E7b"],
}
```
now one can!

## Checklist

- [x] I created an issue and discussed solutions with others.
- [x] I wrote tests or updated tests regarding my changes.
- [x] I follow the style guidelines of this project.
- [x] I have commented my code. So, other can understand what I did.
- [x] I checked if all tests passing after my changes.

## PR review

Anyone in the community is free to review the PR once the tests have passed.

- [x] Add labels and milestones to the PR so it can be classified.
- [x] Check that all items from the **checklist** are resolved.
- [x] Is this pull request ready for review?