### PR TITLE
81-calculated_phd_durations

### DIFF
--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -11,6 +11,7 @@ import pandas as pd
 from n2survey.lime.structure import read_lime_questionnaire_structure
 from n2survey.lime.transformations import (
     range_to_numerical,
+    calculate_phd_duration,
     rate_mental_health,
     rate_supervision,
 )
@@ -382,11 +383,11 @@ class LimeSurvey:
             for question in questions:
                 self.add_responses(self.transform_question(question, transform))
 
-    def transform_question(self, question: str, transform: str):
+    def transform_question(self, question: Union[str, tuple], transform: str):
         """Perform transformation on responses to given question
 
         Args:
-            question (str): Question to transform
+            question (str or tuple of str): Question(s) to transform
             transform (str): Type of transform to perform
 
         Returns:
@@ -399,6 +400,7 @@ class LimeSurvey:
             "depression": "mental_health",
             "supervision": "supervision",
             "range": "range_to_numerical",
+            "phd_duration": "duration",
         }
 
         if transform_dict.get(transform) == "mental_health":
@@ -417,7 +419,11 @@ class LimeSurvey:
         elif transform_dict.get(transform) == "range_to_numerical":
             return range_to_numerical(
                 question_label=self.get_label(question),
-                responses=self.get_responses(question),
+                responses=self.get_responses(question),)
+        elif transform_dict.get(transform) == "duration":
+            return calculate_phd_duration(
+                start_responses=self.get_responses(question[0], labels=False),
+                end_responses=self.get_responses(question[1], labels=False),
             )
 
     def __copy__(self):

--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from n2survey.lime.structure import read_lime_questionnaire_structure
 from n2survey.lime.transformations import (
-    calculate_phd_duration,
+    calculate_duration,
     range_to_numerical,
     rate_mental_health,
     rate_supervision,
@@ -404,7 +404,7 @@ class LimeSurvey:
             "depression": "mental_health",
             "supervision": "supervision",
             "range": "range_to_numerical",
-            "phd_duration": "duration",
+            "duration": "duration",
         }
 
         if transform_dict.get(transform) == "mental_health":
@@ -426,7 +426,7 @@ class LimeSurvey:
                 responses=self.get_responses(question),
             )
         elif transform_dict.get(transform) == "duration":
-            return calculate_phd_duration(
+            return calculate_duration(
                 start_responses=self.get_responses(question[0], labels=False),
                 end_responses=self.get_responses(question[1], labels=False),
             )

--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -11,9 +11,9 @@ import pandas as pd
 from n2survey.lime.structure import read_lime_questionnaire_structure
 from n2survey.lime.transformations import (
     range_to_numerical,
-    calculate_phd_duration,
     rate_mental_health,
     rate_supervision,
+    calculate_phd_duration,
 )
 from n2survey.plot import (
     likert_bar_plot,
@@ -64,10 +64,8 @@ def _clean_file_name(filename: str) -> str:
 
 def _split_plot_kwargs(mixed_kwargs: dict) -> tuple[dict, dict]:
     """Split dict of arguments into theme and non-theme arguments
-
     Args:
         mixed_kwargs (dict): Initial dict of mixed arguments
-
     Returns:
         tuple[dict, dict]: Tuple of (<theme arguements>, <non-theme arguments>)
     """
@@ -78,11 +76,9 @@ def _split_plot_kwargs(mixed_kwargs: dict) -> tuple[dict, dict]:
 
 def deep_dict_update(source: dict, update_dict: dict) -> dict:
     """Recursive dictionary update
-
     Args:
         source (dict): Source dictionary to update
         update_dict (dict): Dictionary with "new" data
-
     Returns:
         dict: Upated dictionary. Neasted dictionaries are updated recursevely
           Neasted lists are combined.
@@ -207,6 +203,10 @@ class LimeSurvey:
                 "A5": "very dissatisfied",
             },
         },
+        "phd_duration": {
+            "label": "What is the length of PhD?",
+            "type": "free",
+        },
     }
 
     def __init__(
@@ -216,7 +216,6 @@ class LimeSurvey:
         output_folder: Optional[str] = None,
     ) -> None:
         """Get an instance of the Survey
-
         Args:
             structure_file (str, optional): Path to the structure XML file
             theme (Optional[dict], optional): seaborn theme parameters.
@@ -242,7 +241,6 @@ class LimeSurvey:
 
     def read_structure(self, structure_file: str) -> None:
         """Read structure XML file
-
         Args:
             structure_file (str): Path to the structure XML file
         """
@@ -267,13 +265,11 @@ class LimeSurvey:
         self, responses_file: str, transformation_questions: dict = {}
     ) -> None:
         """Read responses CSV file
-
         Args:
             responses_file (str): Path to the responses CSV file
             transformation_questions (dict, optional): Dict of questions
                 requiring transformation of raw data, e.g. {'depression': 'D3'}
                 or {'supervision': ['E7a', 'E7b']}
-
         """
 
         # Read 1st line of the csv file
@@ -385,11 +381,9 @@ class LimeSurvey:
 
     def transform_question(self, question: Union[str, tuple], transform: str):
         """Perform transformation on responses to given question
-
         Args:
             question (str or tuple of str): Question(s) to transform
             transform (str): Type of transform to perform
-
         Returns:
             pd.DataFrame: Transformed DataFrame to be concatenated to self.responses
         """
@@ -419,7 +413,8 @@ class LimeSurvey:
         elif transform_dict.get(transform) == "range_to_numerical":
             return range_to_numerical(
                 question_label=self.get_label(question),
-                responses=self.get_responses(question),)
+                responses=self.get_responses(question),
+            )
         elif transform_dict.get(transform) == "duration":
             return calculate_phd_duration(
                 start_responses=self.get_responses(question[0], labels=False),
@@ -428,7 +423,6 @@ class LimeSurvey:
 
     def __copy__(self):
         """Create a shallow copy of the LimeSurvey instance
-
         Returns:
             LimeSurvey: a shallow copy of the LimeSurvey instance
         """
@@ -439,7 +433,6 @@ class LimeSurvey:
 
     def __deepcopy__(self, memo_dict={}):
         """Create a deep copy of the LimeSurvey instance
-
         Returns:
             LimeSurvey: a deep copy of the LimeSurvey instance
         """
@@ -457,16 +450,13 @@ class LimeSurvey:
         drop_other: bool = False,
     ) -> pd.DataFrame:
         """Get responses for a given question with or without labels
-
         Args:
             question (str): Question to get the responses for.
             labels (bool, optional): If the response consists of labels or not (default True).
             drop_other (bool, optional): Whether to exclude contingent question (i.e. "other")
-
         Raises:
             ValueError: Inconsistent question types within question groups.
             ValueError: Unknown question types.
-
         Returns:
             [pd.DataFrame]: The response for the selected question.
         """
@@ -518,11 +508,9 @@ class LimeSurvey:
         self, key: Union[pd.Series, pd.DataFrame, str, list, tuple]
     ) -> "LimeSurvey":
         """Retrieve or slice the responses DataFrame
-
         Args:
             key (pd.Series, pd.DataFrame, str, list, or tuple): A key for
                 DataFrame slicing or get_responses method
-
         Returns:
             LimeSurvey: A copy of LimeSurvey instance with filtered responses
                 DataFrame
@@ -569,11 +557,9 @@ class LimeSurvey:
 
     def query(self, expr: str) -> "LimeSurvey":
         """Filter responses DataFrame with a boolean expression
-
         Args:
             expr (str): Condition str for pd.DataFrame.query().
                 E.g. "A6 == 'A3' & "B2 == 'A5'"
-
         Returns:
             LimeSurvey: LimeSurvey with filtered responses
         """
@@ -588,10 +574,8 @@ class LimeSurvey:
     def filter_na(self, question: str) -> "LimeSurvey":
         """Filter out entries in responses DataFrame with no answer
         to specified question.
-
         Args:
             question (str): Question to which the entries are filtered.
-
         returns:
             LimeSurvey: LimeSurvey with filtered responses.
         """
@@ -614,7 +598,6 @@ class LimeSurvey:
         percents: bool = False,
     ) -> pd.DataFrame:
         """Get counts for a question or a single column
-
         Args:
             question (str): Name of a question group or a sinlge column
             labels (bool, optional): Use labels instead of codes. Defaults to True.
@@ -625,10 +608,8 @@ class LimeSurvey:
             percents (bool, optional): Output percents instead of counts.
               Calculted with respent to the total number of repondents.
               Defaults to False.
-
         Raises:
             AssertionError: Unexpected question type
-
         Returns:
             pd.DataFrame: Counts for a given question/column.
               * For question with choices, counts are ordered accordingly and
@@ -703,11 +684,9 @@ class LimeSurvey:
 
     def _get_dtype_info(self, columns, renamed_columns):
         """Get dtypes for columns in data csv
-
         Args:
             columns (list): List of column names from data csv
             renamed_columns (list): List of column names modified to match self.questions entries
-
         Returns:
             dict: Dictionary of column names and dtypes
             list: List of datetime columns
@@ -796,7 +775,6 @@ class LimeSurvey:
             'compare_with':
                 correlates answers of 'question' with answers
                 of the question given to the 'compare_with' variable.
-
                 'legend_columns':
                     number of columns of the legend added by 'compare_with' on
                     top of the Plot
@@ -839,13 +817,11 @@ class LimeSurvey:
                 'dpi': Resolution in dotsperinch for saved file, if you want to
                     specify. If not, the resolution is taken from the figure
                     resolution only applies to .png, not to .pdf
-
             'answer_sequence': getting the answers in the right order made the
                 inclusion of an answer_sequence variable necessary, which also
                 can be used if you want to give the order of bars yourself,
                 just add in a list with the answers as entries in the order you
                 want
-
             'calculate_aspect_ratio': True or False, if False, aspect ratio is
                 taken from theme, if True aspect ratio of picture is calculated
                 from number of bars and 'bar_width'
@@ -1238,13 +1214,11 @@ class LimeSurvey:
 
     def get_question(self, question: str, drop_other: bool = False) -> pd.DataFrame:
         """Get question structure (i.e. subset from self.questions)
-
         Args:
             question (str): Name of question or subquestion
             drop_other (bool, optional): Whether to exclude contingent question (i.e. "other")
         Raises:
             ValueError: There is no such question or subquestion
-
         Returns:
             pd.DataFrame: Subset from `self.questions` with corresponding rows
         """
@@ -1266,7 +1240,6 @@ class LimeSurvey:
         self, name: str, responses: Union[pd.Series, pd.DataFrame] = None, **kwargs
     ):
         """Add question to self.questions DataFrame
-
         Args:
             name (str): Name (id) of the question to add, e.g. "A12"
             responses (pd.Series or pd.DataFrame, optional): responses
@@ -1294,7 +1267,6 @@ class LimeSurvey:
         question: Union[list, str] = None,
     ):
         """Add responses to specified question to self.responses DataFrame
-
         Args:
             responses (pd.Series or pd.DataFrame): responses to be added
                 to self.responses
@@ -1321,14 +1293,11 @@ class LimeSurvey:
 
     def get_question_type(self, question: str) -> str:
         """Get question type and validate it
-
         Args:
             question (str): question or column code
-
         Raises:
             AssertionError: Unconsistent question types within question
             AssertionError: Unexpected question type
-
         Returns:
             str: Question type like "single-choice", "array", etc.
         """
@@ -1349,10 +1318,8 @@ class LimeSurvey:
 
     def get_label(self, question: str) -> str:
         """Get label for the corresponding column or group of colums
-
         Args:
             question (str): Name of question or subquestion
-
         Returns:
             str: question label/title
         """
@@ -1368,16 +1335,13 @@ class LimeSurvey:
 
     def get_choices(self, question: str) -> dict:
         """Get choices of a question
-
         * For multiple-choice group, format is `<subquestion code: subquestion title>`,
         for example, {"C3_SQ001": "I do not like scientific work.", "C3_SQ002": ...}
         * For all other fixed questions (i.e. array, single choice, subquestion), returns
           choices of that question or column
         * For free and contingent, returns None
-
         Args:
             question (str): Name of question or subquestion to retrieve
-
         Returns:
             dict: dict of choices mappings
         """
@@ -1407,7 +1371,6 @@ class LimeSurvey:
         verbose: bool = True,
     ):
         """Export anonymised data for question to file
-
         Args:
             organisation (str): Name of the organisation to which the
                 exported data belong
@@ -1418,7 +1381,6 @@ class LimeSurvey:
                 save csv file. Default is the current working directory.
             verbose (bool, optional): Whether to display checks for similarity
                 after random permutation. Default is True
-
         """
         # If no dierctory specified, use current working direction
         if not directory:

--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -64,8 +64,10 @@ def _clean_file_name(filename: str) -> str:
 
 def _split_plot_kwargs(mixed_kwargs: dict) -> tuple[dict, dict]:
     """Split dict of arguments into theme and non-theme arguments
+
     Args:
         mixed_kwargs (dict): Initial dict of mixed arguments
+
     Returns:
         tuple[dict, dict]: Tuple of (<theme arguements>, <non-theme arguments>)
     """
@@ -76,9 +78,11 @@ def _split_plot_kwargs(mixed_kwargs: dict) -> tuple[dict, dict]:
 
 def deep_dict_update(source: dict, update_dict: dict) -> dict:
     """Recursive dictionary update
+
     Args:
         source (dict): Source dictionary to update
         update_dict (dict): Dictionary with "new" data
+
     Returns:
         dict: Upated dictionary. Neasted dictionaries are updated recursevely
           Neasted lists are combined.
@@ -216,6 +220,7 @@ class LimeSurvey:
         output_folder: Optional[str] = None,
     ) -> None:
         """Get an instance of the Survey
+
         Args:
             structure_file (str, optional): Path to the structure XML file
             theme (Optional[dict], optional): seaborn theme parameters.
@@ -241,6 +246,7 @@ class LimeSurvey:
 
     def read_structure(self, structure_file: str) -> None:
         """Read structure XML file
+
         Args:
             structure_file (str): Path to the structure XML file
         """
@@ -265,11 +271,13 @@ class LimeSurvey:
         self, responses_file: str, transformation_questions: dict = {}
     ) -> None:
         """Read responses CSV file
+
         Args:
             responses_file (str): Path to the responses CSV file
             transformation_questions (dict, optional): Dict of questions
                 requiring transformation of raw data, e.g. {'depression': 'D3'}
                 or {'supervision': ['E7a', 'E7b']}
+
         """
 
         # Read 1st line of the csv file
@@ -381,9 +389,11 @@ class LimeSurvey:
 
     def transform_question(self, question: Union[str, tuple], transform: str):
         """Perform transformation on responses to given question
+
         Args:
             question (str or tuple of str): Question(s) to transform
             transform (str): Type of transform to perform
+
         Returns:
             pd.DataFrame: Transformed DataFrame to be concatenated to self.responses
         """
@@ -423,6 +433,7 @@ class LimeSurvey:
 
     def __copy__(self):
         """Create a shallow copy of the LimeSurvey instance
+
         Returns:
             LimeSurvey: a shallow copy of the LimeSurvey instance
         """
@@ -433,6 +444,7 @@ class LimeSurvey:
 
     def __deepcopy__(self, memo_dict={}):
         """Create a deep copy of the LimeSurvey instance
+
         Returns:
             LimeSurvey: a deep copy of the LimeSurvey instance
         """
@@ -450,13 +462,16 @@ class LimeSurvey:
         drop_other: bool = False,
     ) -> pd.DataFrame:
         """Get responses for a given question with or without labels
+
         Args:
             question (str): Question to get the responses for.
             labels (bool, optional): If the response consists of labels or not (default True).
             drop_other (bool, optional): Whether to exclude contingent question (i.e. "other")
+
         Raises:
             ValueError: Inconsistent question types within question groups.
             ValueError: Unknown question types.
+
         Returns:
             [pd.DataFrame]: The response for the selected question.
         """
@@ -508,9 +523,11 @@ class LimeSurvey:
         self, key: Union[pd.Series, pd.DataFrame, str, list, tuple]
     ) -> "LimeSurvey":
         """Retrieve or slice the responses DataFrame
+
         Args:
             key (pd.Series, pd.DataFrame, str, list, or tuple): A key for
                 DataFrame slicing or get_responses method
+
         Returns:
             LimeSurvey: A copy of LimeSurvey instance with filtered responses
                 DataFrame
@@ -557,9 +574,11 @@ class LimeSurvey:
 
     def query(self, expr: str) -> "LimeSurvey":
         """Filter responses DataFrame with a boolean expression
+
         Args:
             expr (str): Condition str for pd.DataFrame.query().
                 E.g. "A6 == 'A3' & "B2 == 'A5'"
+
         Returns:
             LimeSurvey: LimeSurvey with filtered responses
         """
@@ -574,8 +593,10 @@ class LimeSurvey:
     def filter_na(self, question: str) -> "LimeSurvey":
         """Filter out entries in responses DataFrame with no answer
         to specified question.
+
         Args:
             question (str): Question to which the entries are filtered.
+
         returns:
             LimeSurvey: LimeSurvey with filtered responses.
         """
@@ -598,6 +619,7 @@ class LimeSurvey:
         percents: bool = False,
     ) -> pd.DataFrame:
         """Get counts for a question or a single column
+
         Args:
             question (str): Name of a question group or a sinlge column
             labels (bool, optional): Use labels instead of codes. Defaults to True.
@@ -608,8 +630,10 @@ class LimeSurvey:
             percents (bool, optional): Output percents instead of counts.
               Calculted with respent to the total number of repondents.
               Defaults to False.
+
         Raises:
             AssertionError: Unexpected question type
+
         Returns:
             pd.DataFrame: Counts for a given question/column.
               * For question with choices, counts are ordered accordingly and
@@ -684,9 +708,11 @@ class LimeSurvey:
 
     def _get_dtype_info(self, columns, renamed_columns):
         """Get dtypes for columns in data csv
+
         Args:
             columns (list): List of column names from data csv
             renamed_columns (list): List of column names modified to match self.questions entries
+
         Returns:
             dict: Dictionary of column names and dtypes
             list: List of datetime columns
@@ -775,6 +801,7 @@ class LimeSurvey:
             'compare_with':
                 correlates answers of 'question' with answers
                 of the question given to the 'compare_with' variable.
+
                 'legend_columns':
                     number of columns of the legend added by 'compare_with' on
                     top of the Plot
@@ -817,11 +844,13 @@ class LimeSurvey:
                 'dpi': Resolution in dotsperinch for saved file, if you want to
                     specify. If not, the resolution is taken from the figure
                     resolution only applies to .png, not to .pdf
+
             'answer_sequence': getting the answers in the right order made the
                 inclusion of an answer_sequence variable necessary, which also
                 can be used if you want to give the order of bars yourself,
                 just add in a list with the answers as entries in the order you
                 want
+
             'calculate_aspect_ratio': True or False, if False, aspect ratio is
                 taken from theme, if True aspect ratio of picture is calculated
                 from number of bars and 'bar_width'
@@ -1214,11 +1243,13 @@ class LimeSurvey:
 
     def get_question(self, question: str, drop_other: bool = False) -> pd.DataFrame:
         """Get question structure (i.e. subset from self.questions)
+
         Args:
             question (str): Name of question or subquestion
             drop_other (bool, optional): Whether to exclude contingent question (i.e. "other")
         Raises:
             ValueError: There is no such question or subquestion
+
         Returns:
             pd.DataFrame: Subset from `self.questions` with corresponding rows
         """
@@ -1240,6 +1271,7 @@ class LimeSurvey:
         self, name: str, responses: Union[pd.Series, pd.DataFrame] = None, **kwargs
     ):
         """Add question to self.questions DataFrame
+
         Args:
             name (str): Name (id) of the question to add, e.g. "A12"
             responses (pd.Series or pd.DataFrame, optional): responses
@@ -1267,6 +1299,7 @@ class LimeSurvey:
         question: Union[list, str] = None,
     ):
         """Add responses to specified question to self.responses DataFrame
+
         Args:
             responses (pd.Series or pd.DataFrame): responses to be added
                 to self.responses
@@ -1293,11 +1326,14 @@ class LimeSurvey:
 
     def get_question_type(self, question: str) -> str:
         """Get question type and validate it
+
         Args:
             question (str): question or column code
+
         Raises:
             AssertionError: Unconsistent question types within question
             AssertionError: Unexpected question type
+
         Returns:
             str: Question type like "single-choice", "array", etc.
         """
@@ -1318,8 +1354,10 @@ class LimeSurvey:
 
     def get_label(self, question: str) -> str:
         """Get label for the corresponding column or group of colums
+
         Args:
             question (str): Name of question or subquestion
+
         Returns:
             str: question label/title
         """
@@ -1335,13 +1373,16 @@ class LimeSurvey:
 
     def get_choices(self, question: str) -> dict:
         """Get choices of a question
+
         * For multiple-choice group, format is `<subquestion code: subquestion title>`,
         for example, {"C3_SQ001": "I do not like scientific work.", "C3_SQ002": ...}
         * For all other fixed questions (i.e. array, single choice, subquestion), returns
           choices of that question or column
         * For free and contingent, returns None
+
         Args:
             question (str): Name of question or subquestion to retrieve
+
         Returns:
             dict: dict of choices mappings
         """
@@ -1371,6 +1412,7 @@ class LimeSurvey:
         verbose: bool = True,
     ):
         """Export anonymised data for question to file
+
         Args:
             organisation (str): Name of the organisation to which the
                 exported data belong
@@ -1381,6 +1423,7 @@ class LimeSurvey:
                 save csv file. Default is the current working directory.
             verbose (bool, optional): Whether to display checks for similarity
                 after random permutation. Default is True
+
         """
         # If no dierctory specified, use current working direction
         if not directory:

--- a/n2survey/lime/transformations.py
+++ b/n2survey/lime/transformations.py
@@ -325,7 +325,6 @@ def calculate_phd_duration(start_responses: pd.DataFrame, end_responses: pd.Data
 
     # duration calculation, return as day
     df["PhD duration (days)"] = df.iloc[:, 1] - df.iloc[:, 0]
-    df["PhD duration (days)"] = df["PhD duration (days)"].dt.days
 
     # convert days to month and year
     df["PhD duration (months)"] = df.iloc[:, 2] / np.timedelta64("1", "M")

--- a/n2survey/lime/transformations.py
+++ b/n2survey/lime/transformations.py
@@ -7,8 +7,8 @@ __all__ = [
     "rate_supervision",
     "rate_mental_health",
     "range_to_numerical",
+    "calculate_phd_duration",
 ]
-
 
 def rate_supervision(
     question_label: str,
@@ -249,7 +249,7 @@ def rate_mental_health(
 
 
 def strRange_to_intRange(strAnswer: str) -> int:
-
+    
     """Calculate the mean of all numbers present in a string.
 
     Args:

--- a/n2survey/lime/transformations.py
+++ b/n2survey/lime/transformations.py
@@ -325,6 +325,7 @@ def calculate_phd_duration(start_responses: pd.DataFrame, end_responses: pd.Data
 
     # duration calculation, return as day
     df["PhD duration (days)"] = df.iloc[:, 1] - df.iloc[:, 0]
+    df["PhD duration (days)"] = df["PhD duration (days)"].dt.days
 
     # convert days to month and year
     df["PhD duration (months)"] = df.iloc[:, 2] / np.timedelta64("1", "M")

--- a/n2survey/lime/transformations.py
+++ b/n2survey/lime/transformations.py
@@ -308,3 +308,32 @@ def range_to_numerical(question_label: str, responses: pd.DataFrame) -> pd.DataF
     df[f"{new_question_label}"] = responses_numerical
 
     return df
+
+def calculate_phd_duration(start_responses: pd.DataFrame, end_responses: pd.DataFrame):
+    """Calculate PhD duration
+    Args:
+        start_responses (pd.DataFrame): DataFrame containing responses data of the start of duration
+        end_responses (pd.DataFrame): DataFrame containing responses data of the end of duration
+    Returns:
+        pd.DataFrame: Rounded PhD duration in days, months and years"""
+
+    # get labels of start and end questions to get their data
+    df = pd.concat(
+        [start_responses, end_responses],
+        axis=1,
+    )
+
+    # duration calculation, return as day
+    df["PhD duration (days)"] = df.iloc[:, 1] - df.iloc[:, 0]
+
+    # convert days to month and year
+    df["PhD duration (months)"] = df.iloc[:, 2] / np.timedelta64("1", "M")
+    df["PhD duration (years)"] = df.iloc[:, 2] / np.timedelta64("1", "Y")
+
+    # convert PhD duration (days) to float type for consistency
+    df["PhD duration (days)"] = df["PhD duration (days)"].dt.days
+
+    # drop temporary columns used for duration calculation and return only duration in day, month and year
+    df = df.iloc[:, 2:].round()
+
+    return df

--- a/n2survey/lime/transformations.py
+++ b/n2survey/lime/transformations.py
@@ -7,7 +7,7 @@ __all__ = [
     "rate_supervision",
     "rate_mental_health",
     "range_to_numerical",
-    "calculate_phd_duration",
+    "calculate_duration",
 ]
 
 
@@ -311,13 +311,16 @@ def range_to_numerical(question_label: str, responses: pd.DataFrame) -> pd.DataF
     return df
 
 
-def calculate_phd_duration(start_responses: pd.DataFrame, end_responses: pd.DataFrame):
-    """Calculate PhD duration
+def calculate_duration(start_responses: pd.DataFrame, end_responses: pd.DataFrame):
+    """Calculate duration
+
     Args:
         start_responses (pd.DataFrame): DataFrame containing responses data of the start of duration
         end_responses (pd.DataFrame): DataFrame containing responses data of the end of duration
+
     Returns:
-        pd.DataFrame: Rounded PhD duration in days, months and years"""
+        pd.DataFrame: Rounded PhD duration in days, months and years
+    """
 
     # get labels of start and end questions to get their data
     df = pd.concat(
@@ -335,7 +338,8 @@ def calculate_phd_duration(start_responses: pd.DataFrame, end_responses: pd.Data
     # convert PhD duration (days) to float type for consistency
     df["PhD duration (days)"] = df["PhD duration (days)"].dt.days
 
-    # drop temporary columns used for duration calculation and return only duration in day, month and year
+    # drop temporary columns used for duration calculation
+    # and return only duration in day, month and year
     df = df.iloc[:, 2:].round()
 
     return df

--- a/tests/test_lime_survey.py
+++ b/tests/test_lime_survey.py
@@ -144,6 +144,11 @@ class TestLimeSurveyInitialisation(BaseTestLimeSurvey2021Case):
                 },
                 "is_contingent": False,
             },
+            "phd_duration": {
+                "label": "What is the length of PhD?",
+                "type": "free",
+                "is_contingent": False,
+            },
         }
         question_df = pd.concat(
             [
@@ -318,6 +323,31 @@ class TestLimeSurveyReadResponses(BaseTestLimeSurvey2021WithResponsesCase):
         # "id" of dataframe starts at 2, therefore difference to "index" above
         self.assert_df_equal(
             survey.responses.iloc[:3, -7:], ref, msg="DataFrames not equal."
+        )
+
+    def test_phd_duration_transformation_questions(self):
+        """Test adding responses to transformation questions in read_responses"""
+
+        phd_duration_questions = {"phd_duration": ("A8", "A9")}
+
+        survey = LimeSurvey(structure_file=self.structure_file)
+        survey.read_responses(
+            responses_file=self.responses_file,
+            transformation_questions=phd_duration_questions,
+        )
+        
+        ref = pd.DataFrame(
+            data={
+                "PhD duration (days)": np.array([1826.0, 1095.0, 1065.0]),
+                "PhD duration (months)": np.array([60.0, 36.0, 35.0]),
+                "PhD duration (years)": np.array([5.0, 3.0, 3.0]),
+            },
+            index=[2, 3, 4],
+        )
+        ref.index.name = "id"
+        # "id" of dataframe starts at 2, therefore difference to "index" above
+        self.assert_df_equal(
+            survey.responses.iloc[:3, -3:], ref, msg="DataFrames not equal."
         )
 
     def test_single_choice_dtype(self):

--- a/tests/test_lime_survey.py
+++ b/tests/test_lime_survey.py
@@ -427,7 +427,6 @@ class TestLimeSurveyReadResponses(BaseTestLimeSurvey2021WithResponsesCase):
             True,
         )
 
-
 class TestLimeSurveyTransformQuestion(BaseTestLimeSurvey2021WithResponsesCase):
     """Test LimeSurvey transform_question"""
 

--- a/tests/test_lime_survey.py
+++ b/tests/test_lime_survey.py
@@ -325,10 +325,11 @@ class TestLimeSurveyReadResponses(BaseTestLimeSurvey2021WithResponsesCase):
             survey.responses.iloc[:3, -7:], ref, msg="DataFrames not equal."
         )
 
-    def test_phd_duration_transformation_questions(self):
-        """Test adding responses to transformation questions in read_responses"""
+    def test_duration_transformation_questions(self):
+        """Test adding responses to duration transformation
+        questions in read_responses"""
 
-        phd_duration_questions = {"phd_duration": ("A8", "A9")}
+        phd_duration_questions = {"duration": ("A8", "A9")}
 
         survey = LimeSurvey(structure_file=self.structure_file)
         survey.read_responses(

--- a/tests/test_lime_transformations.py
+++ b/tests/test_lime_transformations.py
@@ -359,5 +359,37 @@ class TestRangeToNumerical(BaseTestLimeSurvey2021WithResponsesCase):
         self.assert_df_equal(result.iloc[:3, -1:], ref, msg="DataFrames not equal.")
 
 
+class TestPhDDuration(BaseTestLimeSurvey2021WithResponsesCase):
+    """Test Transformations calculate_phd_duration"""
+
+    def test_phd_duration(self):
+        """Test calculated phd duration"""
+
+        start_question = "A8"
+        end_question = "A9"
+        # phd_duration_questions = {"phd_duration": ("A8", "A9")}
+
+        result = calculate_phd_duration(
+            start_responses=self.survey.get_responses(start_question, labels=False),
+            end_responses=self.survey.get_responses(end_question, labels=False),
+        )
+        # survey = LimeSurvey(structure_file=self.structure_file)
+        # survey.read_responses(
+        #     responses_file=self.responses_file,
+        #     transformation_questions=phd_duration_questions,
+        # )
+        ref = pd.DataFrame(
+            data={
+                "PhD duration (days)": [1826.0, 1095.0, 1065.0],
+                "PhD duration (months)": [60.0, 36.0, 35.0],
+                "PhD duration (years)": [5.0, 3.0, 3.0],
+            },
+            index=[2, 3, 4],
+        )
+        ref.index.name = "id"
+        # "id" of dataframe starts at 2, therefore difference to "index" above
+        self.assert_df_equal(result.iloc[:3, :], ref, msg="DataFrames not equal.")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lime_transformations.py
+++ b/tests/test_lime_transformations.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 from n2survey.lime.transformations import (
-    calculate_phd_duration,
+    calculate_duration,
     range_to_numerical,
     rate_mental_health,
     rate_supervision,
@@ -198,16 +198,16 @@ class TestRateSupervision(BaseTestLimeSurvey2021WithResponsesCase):
         self.assert_df_equal(result.iloc[6:9, -2:], ref, msg="DataFrames not equal.")
 
 
-class TestPhDDuration(BaseTestLimeSurvey2021WithResponsesCase):
-    """Test Transformations calculate_phd_duration"""
+class TestDuration(BaseTestLimeSurvey2021WithResponsesCase):
+    """Test Transformation calculate_duration"""
 
     def test_phd_duration(self):
-        """Test calculated phd duration"""
+        """Test calculate_duration"""
 
         start_question = "A8"
         end_question = "A9"
 
-        result = calculate_phd_duration(
+        result = calculate_duration(
             start_responses=self.survey.get_responses(start_question, labels=False),
             end_responses=self.survey.get_responses(end_question, labels=False),
         )

--- a/tests/test_lime_transformations.py
+++ b/tests/test_lime_transformations.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from n2survey.lime.transformations import (
     range_to_numerical,
+    calculate_phd_duration,
     rate_mental_health,
     rate_supervision,
 )
@@ -196,6 +197,31 @@ class TestRateSupervision(BaseTestLimeSurvey2021WithResponsesCase):
         # "id" of dataframe starts at 2, therefore difference to "index" above
         self.assert_df_equal(result.iloc[6:9, -2:], ref, msg="DataFrames not equal.")
 
+class TestPhDDuration(BaseTestLimeSurvey2021WithResponsesCase):
+    """Test Transformations calculate_phd_duration"""
+
+    def test_phd_duration(self):
+        """Test calculated phd duration"""
+
+        start_question = "A8"
+        end_question = "A9"
+
+        result = calculate_phd_duration(
+            start_responses=self.survey.get_responses(start_question, labels=False),
+            end_responses=self.survey.get_responses(end_question, labels=False),
+        )
+
+        ref = pd.DataFrame(
+            data={
+                "PhD duration (days)": [1826.0, 1095.0, 1065.0],
+                "PhD duration (months)": [60.0, 36.0, 35.0],
+                "PhD duration (years)": [5.0, 3.0, 3.0],
+            },
+            index=[2, 3, 4],
+        )
+        ref.index.name = "id"
+        # "id" of dataframe starts at 2, therefore difference to "index" above
+        self.assert_df_equal(result.iloc[:3, :], ref, msg="DataFrames not equal.")
 
 class TestRangeToNumerical(BaseTestLimeSurvey2021WithResponsesCase):
     """Test Transformations range for different questions"""


### PR DESCRIPTION
…n two columns. Originally intended for PhD duration calculation but this function can take other datetime columns for duration calculation too

## Description

I added a new function to calculate duration between two specified columns. The test unit has not yet been modified to include a test for this function. @lheckmann mentioned that I could add this function to the `transform_question` function just like anxiety and supervision functions but since the function that I wrote requires a `start_question` and `end_question` given as argument to the `calculate_phd_duration` function, I am not sure what is the best way to do this, should I add into the docstring to explain that if one wants a duration transformation one has to give `start_question` and `end_question` concatenated with ',' and always in this order?

## Checklist

- [ /] I created an issue and discussed solutions with others.
- [ ] I wrote tests or updated tests regarding my changes.
- [ /] I follow the style guidelines of this project.
- [ /] I have commented my code. So, other can understand what I did.
- [ /] I checked if all tests passing after my changes.

## PR review

Anyone in the community is free to review the PR once the tests have passed.

- [ ] Add labels and milestones to the PR so it can be classified.
- [ ] Check that all items from the **checklist** are resolved.
- [ ] Is this pull request ready for review?