### PR TITLE
Implement filter_na method. Implement test for filter_na method.

### DIFF
--- a/n2survey/lime/survey.py
+++ b/n2survey/lime/survey.py
@@ -579,6 +579,26 @@ class LimeSurvey:
 
         return filtered_survey
 
+    def filter_na(self, question: str) -> "LimeSurvey":
+        """Filter out entries in responses DataFrame with no answer
+        to specified question.
+
+        Args:
+            question (str): Question to which the entries are filtered.
+
+        returns:
+            LimeSurvey: LimeSurvey with filtered responses.
+        """
+
+        # Make copy of LimeSurvey instance
+        filtered_survey = self.__copy__()
+        # Filter responses DataFrame
+        filtered_survey.responses = filtered_survey.responses[
+            filtered_survey.responses[question].notna()
+        ]
+
+        return filtered_survey
+
     def count(
         self,
         question: str,

--- a/tests/test_lime_survey.py
+++ b/tests/test_lime_survey.py
@@ -1411,7 +1411,7 @@ class TestLimeSurveyFilterNa(BaseTestLimeSurvey2021WithResponsesCase):
         filtered_survey = self.survey.filter_na("F5a")
 
         np.testing.assert_equal(
-            list(filtered_survey.responses.index), [20, 10, 28, 31, 37]
+            list(filtered_survey.responses.index), [2, 10, 28, 31, 37]
         )
 
 

--- a/tests/test_lime_survey.py
+++ b/tests/test_lime_survey.py
@@ -1402,5 +1402,18 @@ class TestLimeSurveyQuery(BaseTestLimeSurvey2021WithResponsesCase):
         np.testing.assert_equal(list(filtered_survey.responses.index), [5, 21, 46])
 
 
+class TestLimeSurveyFilterNa(BaseTestLimeSurvey2021WithResponsesCase):
+    """Test LimeSurvey filter_na method"""
+
+    def test_filter_na(self):
+        """Test filter_na method"""
+
+        filtered_survey = self.survey.filter_na("F5a")
+
+        np.testing.assert_equal(
+            list(filtered_survey.responses.index), [20, 10, 28, 31, 37]
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Implement filter_na method for LimeSurvey class to filter out entries with no answer to specified question.

Unlike proposed in the comments in the issue, I believe it makes more sense to implement a separate method for this functionality so that it can be called independently of other filtering actions. Usage is as simple as 

```python
filtered_survey = survey.filter_na("A1")
filtered_survey = survey.filter_na("trait_anxiety_class")
```

Describe your solution:

- Resolve Issue #125 
- Implement new `filter_na` method

## Checklist

- [x] I created an issue and discussed solutions with others.
- [x] I wrote tests or updated tests regarding my changes.
- [x] I follow the style guidelines of this project.
- [x] I have commented my code. So, other can understand what I did.
- [x] I checked if all tests passing after my changes.

## PR review

Anyone in the community is free to review the PR once the tests have passed.

- [x] Add labels and milestones to the PR so it can be classified.
- [x] Check that all items from the **checklist** are resolved.
- [x] Is this pull request ready for review?